### PR TITLE
Fix alignment regex pattern

### DIFF
--- a/lib/octopress-pullquote-tag.rb
+++ b/lib/octopress-pullquote-tag.rb
@@ -20,7 +20,7 @@ module Octopress
 
             quote = RubyPants.new($1).to_html
 
-            alignment = @markup.scan(/(left|right|center)/i).first || 'right'
+            alignment = @markup.scan(/left|right|center/i).first || 'right'
             classnames = @markup.sub(/left|right|center/i, '').strip
 
             output = "<span class='pullquote-#{alignment} #{classnames}' data-pullquote='#{quote}'></span>#{output}"


### PR DESCRIPTION
Return array instead of array of arrays to make the pullquote alignment
output decoration work.

Fixes the error that when using and alignment markup (e.g. {% pullquote _left_ %} ) the output produced was something like
`<span class="pullquote-[&quot;left&quot;] " ...  ></span>`
