### PR TITLE
We now work with Jekyll 3.0.x and https://github.com/jekyll/jekyll/pull/3240

### DIFF
--- a/lib/octopress-pullquote-tag/utils.rb
+++ b/lib/octopress-pullquote-tag/utils.rb
@@ -10,9 +10,9 @@ module Octopress
           txext = site.config['textile_ext']
 
           if mdext.include? ext
-            site.getConverterImpl(Jekyll::Converters::Markdown).convert(content)
+            site.find_converter_instance(Jekyll::Converters::Markdown).convert(content)
           elsif txext.include? ext
-            site.getConverterImpl(Jekyll::Converters::Textile).convert(content)
+            site.find_converter_instance(Jekyll::Converters::Textile).convert(content)
           else
             "<p>" + content.strip.gsub(/\n\n/, "<p>\n\n</p>") + "</p>"
           end


### PR DESCRIPTION
Jekyll 3.0.0 changed their API in https://github.com/jekyll/jekyll/pull/3240, which affects this plugin. The change appears only to rename the method. This pull request has been lightly tested with Jekyll 3.0.6.
